### PR TITLE
Version bump <4.9 to 5.0

### DIFF
--- a/aeson-filthy.cabal
+++ b/aeson-filthy.cabal
@@ -16,7 +16,7 @@ library
   hs-source-dirs:      src
   default-language:    Haskell2010
   ghc-options:         -Wall
-  build-depends:       base >=4.8 && <4.9
+  build-depends:       base >=4.8 && <5.0
                      , aeson
                      , bytestring
                      , text


### PR DESCRIPTION
Need 4.9 for ghc-8.0