### PR TITLE
Fix build for newer versions of time

### DIFF
--- a/src/Data/Aeson/Filthy.hs
+++ b/src/Data/Aeson/Filthy.hs
@@ -256,7 +256,7 @@ instance FromJSON RFC2822Time where
               -- This allows some whitespace in places it isn't allowed. Also the RFC definition of
               -- whitespace is more permissive then spaces and newlines.
               let ts = T.unpack . T.replace " " "" . T.replace "\n" "" $ t
-              in case getFirst . foldMap (\f -> parseTimeM True defaultTimeLocale f ts) $ (
+              in case getFirst . foldMap (\f -> First $ parseTimeM True defaultTimeLocale f ts) $ (
                  do -- Generate the allows RFC2822 time format following its ABNF.
                    -- The day of week is optional
                    dow  <- ["", "%a,"]

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,1 +1,1 @@
-resolver: nightly-2018-06-08
+resolver: lts-16.23


### PR DESCRIPTION
This simple patch makes `aeson-filthy` compatible with newer versions of `time`, where `parseTimeM` requires `MonadFail`, due to changes in the base library. `First` doesn't have a `MonadFail` instance, so I used `Maybe`'s instead. The same code should work for older versions of `time` too.